### PR TITLE
update to reflect latest config defaults

### DIFF
--- a/khaos.json
+++ b/khaos.json
@@ -5,11 +5,6 @@
       "label": "What's your integration's name?",
       "hint": "(eg. \"Google Analytics\")"
     },
-    "assumesPageview": {
-      "type": "boolean",
-      "label": "Does your library always record a pageview when loaded?",
-      "hint": "(\"yes\" or \"no\", most do)"
-    },
     "identify":{
       "type": "boolean",
       "label": "Does your integration record a visitor's identity?",

--- a/template/.eslintrc
+++ b/template/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "extends": "segment/browser",
+
+  "rules": {
+    "global-strict": 0,
+    "max-len": 0,
+    "strict": 1
+  },
+
+  "globals": {
+    "exports": true,
+    "module": true,
+    "require": true
+  }
+}

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,0 +1,5 @@
+*.log
+.DS_Store
+build.js
+components
+node_modules

--- a/template/Contributing.md
+++ b/template/Contributing.md
@@ -1,0 +1,55 @@
+# Contributing
+
+We're huge fans of open-source, and we absolutely love getting good contributions to **analytics.js**! Integrations are available to thousands of Segment customers and we have hundreds of integrations in already in our queue, so it's important that you do the following _before writing a pull request_. 
+
+1. Read about our integration options and apply to be a partner: https://segment.com/partners/
+1. Hear from the Segment team before submitting your pull request.
+
+## Getting Set Up
+
+To start, we'll get you set up with our development environment. All of our development scripts and helpers are written in [node.js](http://nodejs.org), so you'll want to install that first by going to [nodejs.org](http://nodejs.org).
+
+Then after forking **analytics.js-integrations** just `cd` into the folder and run `make`:
+
+```bash
+$ cd analytics.js-integration-${ name }
+$ make
+```
+
+That will install all of our [npm](http://npmjs.org) and [component](http://component.io) dependencies and compile the latest version of the development build to test against. You can now add your changes to the library, and run `make test` to make sure everything is passing still.
+
+The commands you'll want to know for development are:
+
+```bash
+$ make               # re-compiles the development build of analytics.js for testing
+$ make test          # runs all of the tests in your terminal
+$ make test-browser  # runs all of the tests in your browser, for nicer debugging
+```
+
+## Writing Tests
+
+Every contribution should be accompanied by matching tests. If you look inside of the `test/` directory, you'll see we're pretty serious about this. That's because:
+
+1. **analytics.js** runs on tons of different types of browsers, operating systems, etc. and we want to make sure it runs well everywhere.
+1. It lets us add new features much, much more quickly.
+1. We aren't insane.
+
+When adding your own integration, the easiest way to figure out what major things to test is to look at everything you've added to the integration `prototype`. You'll want to write testing groups for `#initialize`, `#load`, `#identify`, `#track`, etc. And each group should test all of the expected functionality.
+
+The most important thing to writing clean, easy-to-manage integrations is to **keep them small** and **clean up after each test**, so that the environment is never polluted by an individual test.
+
+If you run into any questions, check out a few of our existing integrations to see how we've done it.
+
+## Contributing Checklist
+
+To help make contributing easy, here's all the things you need to remember:
+
+- Add your integration file to `/lib`.
+- Create a new Integration constructor with the `integration` factory component.
+- Add your integration's default options with `.option()`.
+- Add an `initialize` method to your integration's `prototype`.
+- Add methods you want to support to the `prototype`. (`identify`, `track`, `pageview`, etc.)
+- Write tests for all of your integration's logic.
+- Run the tests and get everything passing.
+- Commit your changes with a nice commit message.
+- Submit your pull request.

--- a/template/History.md
+++ b/template/History.md
@@ -1,0 +1,5 @@
+
+1.0.0 / {{ date }}
+==================
+
+  * Initial commit :sparkles:

--- a/template/License.md
+++ b/template/License.md
@@ -1,0 +1,13 @@
+{{#if isPrivate }}
+Copyright (c) 2015 Segment.io friends@segment.com. All rights reserved. 
+
+{{else}}
+
+Copyright (c) 2015 Segment.io friends@segment.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+{{/if}}

--- a/template/Makefile
+++ b/template/Makefile
@@ -1,0 +1,93 @@
+#
+# Binaries.
+#
+
+DUO = node_modules/.bin/duo
+DUOT = node_modules/.bin/duo-test
+ESLINT = node_modules/.bin/eslint
+
+#
+# Files.
+#
+
+SRCS_DIR = lib
+SRCS = $(shell find $(SRCS_DIR) -type f -name "*.js")
+TESTS_DIR = test
+TESTS = $(shell find $(TESTS_DIR) -type f -name '*.test.js')
+
+#
+# Task config.
+#
+
+BROWSER ?= chrome
+
+PORT ?= 0
+
+DUOT_ARGS = \
+	--reporter spec \
+	--port $(PORT) \
+	--commands "make build"
+
+#
+# Chore tasks.
+#
+
+# Install node dependencies.
+node_modules: package.json $(wildcard node_modules/*/package.json)
+	@npm install
+
+# Remove temporary files and build artifacts.
+clean:
+	rm -rf build.js
+.PHONY: clean
+
+# Remove temporary files, build artifacts, and vendor dependencies.
+distclean: clean
+	rm -rf components node_modules
+.PHONY: distclean
+
+#
+# Build tasks.
+#
+
+# Build all integrations, tests, and dependencies together for testing.
+build.js: node_modules component.json $(SRCS) $(TESTS)
+	@$(DUO) --stdout --development $(TESTS) > $@
+
+# Build shortcut.
+build: build.js
+.DEFAULT_GOAL = build
+
+#
+# Test tasks.
+#
+
+# Lint JavaScript source.
+lint: node_modules
+	@$(ESLINT) $(SRCS) $(TESTS)
+.PHONY: lint
+
+# Test locally in PhantomJS.
+test-phantomjs: node_modules build.js
+	@$(DUOT) phantomjs $(TESTS_DIR) args: \
+		--path node_modules/.bin/phantomjs
+.PHONY: test
+
+# Test locally in the browser.
+test-browser: node_modules build.js
+	@$(DUOT) browser --commands "make build" $(TESTS_DIR)
+.PHONY: test-browser
+
+# Test in Sauce Labs. Note that you must set the SAUCE_USERNAME and
+# SAUCE_ACCESS_KEY environment variables using your Sauce Labs credentials.
+test-sauce: node_modules build.js
+	@$(DUOT) saucelabs $(TESTS_DIR) \
+		--name analytics.js-integrations \
+		--browsers $(BROWSER) \
+		--user $(SAUCE_USERNAME) \
+		--key $(SAUCE_ACCESS_KEY)
+.PHONY: test-sauce
+
+# Test shortcut.
+test: lint test-phantomjs
+.PHONY: test

--- a/template/Readme.md
+++ b/template/Readme.md
@@ -1,0 +1,12 @@
+# analytics.js-integration-{{slugcase name}} [![Build Status][ci-badge]][ci-link]
+
+{{ name }} integration for [Analytics.js][].
+
+## License
+
+Released under the [MIT license](License.md).
+
+
+[Analytics.js]: https://segment.com/docs/libraries/analytics.js/
+[ci-link]: https://circleci.com/gh/segment-integrations/analytics.js-integration-{{slugcase name}}
+[ci-badge]: https://circleci.com/gh/segment-integrations/analytics.js-integration-{{slugcase name}}.svg?style=svg

--- a/template/circle.yml
+++ b/template/circle.yml
@@ -1,0 +1,11 @@
+machine:
+  node:
+    version: 0.12
+dependencies:
+  pre:
+    - echo "github.com,192.30.252.*,192.30.253.*,192.30.254.*,192.30.255.* ssh-rsa $(ssh-keyscan -t rsa github.com | cut -d ' ' -f 3-)" >> ~/.ssh/known_hosts
+    - npm install -g npm@'>=2.7.0'
+    - make
+test:
+  override:
+    - make test

--- a/template/component.json
+++ b/template/component.json
@@ -1,0 +1,16 @@
+{
+  "name": "analytics.js-integration-{{slugcase name }}",
+  "repo": "segment-integrations/analytics.js-integration-{{slugcase name }}",
+  "description": "The {{ name }} analytics.js integration.",
+  "version": "1.0.0",
+  "license": "{{ license }}",
+  "main": "lib/index.js",
+  "dependencies": {
+    "segmentio/analytics.js-integration": "^1.0.0"
+    },
+  "development": {
+    "segmentio/analytics.js-core": "^2.10.0",
+    "segmentio/analytics.js-integration-tester": "1.4.x",
+    "segmentio/clear-env": "0.2.x"
+  }
+}

--- a/template/lib/index.js
+++ b/template/lib/index.js
@@ -1,5 +1,5 @@
 
-var integration = require('integration');
+var integration = require('analytics.js-integration');
 
 /**
  * Expose `plugin`.
@@ -13,8 +13,7 @@ module.exports = exports = function(analytics){
  * Expose `{{pascalcase name}}` integration.
  */
 
-var {{pascalcase name}} = exports.Integration = integration('{{name}}'){{#assumesPageview}}
-  .assumesPageview(){{/assumesPageview}}
+var {{pascalcase name}} = exports.Integration = integration('{{name}}')
   // TODO: add your own options to the chained calls above. For example if
   // {{name}} requires an "API Key" you'd add an option like...
   //
@@ -65,7 +64,7 @@ var {{pascalcase name}} = exports.Integration = integration('{{name}}'){{#assume
   //
   //   return window.__integration;
 };
-{{^assumesPageview}}
+
 /**
  * Trigger a page view.
  *
@@ -83,7 +82,7 @@ var {{pascalcase name}} = exports.Integration = integration('{{name}}'){{#assume
   //   var properties = page.properties();
   //   window.__integration.pageview(name, properties.url);
 };
-{{/assumesPageview}}{{#identify}}
+{{#identify}}
 /**
  * Identify a user.
  *

--- a/template/package.json
+++ b/template/package.json
@@ -1,8 +1,8 @@
 {
   "name": "analytics.js-integration-{{slugcase name }}",
-  {{# isPrivate }}
+  {{#isPrivate}}
   "private": true,
-  {{/ isPrivate }}
+  {{/isPrivate}}
   "description": "The {{ name }} analytics.js integration.",
   "author": "Segment <friends@segment.com>",
   "license": "{{ license }}",

--- a/template/package.json
+++ b/template/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "analytics.js-integration-{{slugcase name }}",
+  {{# isPrivate }}
+  "private": true,
+  {{/ isPrivate }}
+  "description": "The {{ name }} analytics.js integration.",
+  "author": "Segment <friends@segment.com>",
+  "license": "{{ license }}",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "make test"
+  },
+  "engines": {
+    "node": ">=0.12.0",
+    "npm": ">=2.7.0"
+  },
+  "repository": {
+    "url": "https://github.com/segment-integrations/analytics.js-integration-{{slugcase name}}.git",
+    "type": "git"
+  },
+  "bugs": {
+    "url": "https://github.com/segment-integrations/analytics.js-integration-{{slugcase name}}/issues"
+  },
+  "homepage": "https://segment.com/docs/integrations/{{slugcase name}}/",
+  "dependencies": {},
+  "devDependencies": {
+    "duo": "0.12.x",
+    "duo-test": "0.2.x",
+    "eslint": "0.x",
+    "eslint-config-segment": "^1.0.10",
+    "mocha": "^2.2.5",
+    "mocha-phantomjs": "segmentio/mocha-phantomjs#master",
+    "phantomjs": "^1.9.17"
+  }
+}

--- a/template/test/index.html
+++ b/template/test/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>integrations tests</title>
+    <link rel="stylesheet" href="/node_modules/mocha/mocha.css">
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <script src="/saucelabs.js"></script>
+    <script src="/node_modules/mocha/mocha.js"></script>
+    <script>
+      mocha.setup({
+        ui: 'bdd',
+        ignoreLeaks: true,
+        slow: 300,
+        timeout: 10000
+      });
+      var _onload = window.onload;
+      window.onload = function() {
+        if (typeof _onload === 'function') {
+          _onload.apply(this, arguments);
+        }
+        if (window.mochaPhantomJS) {
+          mochaPhantomJS.run();
+        } else if (window.saucelabs) {
+          saucelabs(mocha.run());
+        } else {
+          mocha.run();
+        }
+      };
+    </script>
+    <script src="/build.js"></script>
+  </body>
+</html>

--- a/template/test/index.test.js
+++ b/template/test/index.test.js
@@ -42,8 +42,7 @@ describe('{{name}}', function(){
     // integration('{{name}}')
     //   .global('__myIntegration')
     //   .option('apiKey', '')
-    analytics.compare({{pascalcase name}}, integration('{{name}}'){{#assumesPageview}}
-      .assumesPageview(){{/assumesPageview}})
+    analytics.compare({{pascalcase name}}, integration('{{name}}')
   });
 
   describe('before loading', function(){


### PR DESCRIPTION
I know this is rather limited in its usefulness given the hold on packaged integrations, though i'd like to use it to create the `facebook-ads-for-websites` repo where i intend to merge the two existing fb integrations, and thought maybe it could be of use moving forward. ripped from https://github.com/segment-boneyard/analytics.js-cleaver/tree/master/templates

@ndhoule 